### PR TITLE
feat: Allow extras on models.

### DIFF
--- a/openapi_schema_pydantic/v3/v3_0_3/components.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/components.py
@@ -49,7 +49,7 @@ class Components(BaseModel):
     """An object to hold reusable [Callback Objects](#callbackObject)."""
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {

--- a/openapi_schema_pydantic/v3/v3_0_3/contact.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/contact.py
@@ -26,7 +26,7 @@ class Contact(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {"name": "API Support", "url": "http://www.example.com/support", "email": "support@example.com"}

--- a/openapi_schema_pydantic/v3/v3_0_3/discriminator.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/discriminator.py
@@ -25,7 +25,7 @@ class Discriminator(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {

--- a/openapi_schema_pydantic/v3/v3_0_3/encoding.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/encoding.py
@@ -63,7 +63,7 @@ class Encoding(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {

--- a/openapi_schema_pydantic/v3/v3_0_3/example.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/example.py
@@ -33,7 +33,7 @@ class Example(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {"summary": "A foo example", "value": {"foo": "bar"}},

--- a/openapi_schema_pydantic/v3/v3_0_3/external_documentation.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/external_documentation.py
@@ -19,5 +19,5 @@ class ExternalDocumentation(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {"examples": [{"description": "Find more info here", "url": "https://example.com"}]}

--- a/openapi_schema_pydantic/v3/v3_0_3/header.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/header.py
@@ -17,7 +17,7 @@ class Header(Parameter):
     param_in = Field(default=ParameterLocation.HEADER, const=True, alias="in")
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         allow_population_by_field_name = True
         schema_extra = {
             "examples": [

--- a/openapi_schema_pydantic/v3/v3_0_3/info.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/info.py
@@ -47,7 +47,7 @@ class Info(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {

--- a/openapi_schema_pydantic/v3/v3_0_3/license.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/license.py
@@ -20,5 +20,5 @@ class License(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {"examples": [{"name": "Apache 2.0", "url": "https://www.apache.org/licenses/LICENSE-2.0.html"}]}

--- a/openapi_schema_pydantic/v3/v3_0_3/link.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/link.py
@@ -63,7 +63,7 @@ class Link(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {"operationId": "getUserAddressByUUID", "parameters": {"userUuid": "$response.body#/uuid"}},

--- a/openapi_schema_pydantic/v3/v3_0_3/media_type.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/media_type.py
@@ -49,7 +49,7 @@ class MediaType(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         allow_population_by_field_name = True
         schema_extra = {
             "examples": [

--- a/openapi_schema_pydantic/v3/v3_0_3/oauth_flow.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/oauth_flow.py
@@ -35,7 +35,7 @@ class OAuthFlow(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {

--- a/openapi_schema_pydantic/v3/v3_0_3/oauth_flows.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/oauth_flows.py
@@ -35,4 +35,4 @@ class OAuthFlows(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow

--- a/openapi_schema_pydantic/v3/v3_0_3/open_api.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/open_api.py
@@ -68,4 +68,4 @@ class OpenAPI(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow

--- a/openapi_schema_pydantic/v3/v3_0_3/operation.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/operation.py
@@ -104,7 +104,7 @@ class Operation(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {

--- a/openapi_schema_pydantic/v3/v3_0_3/parameter.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/parameter.py
@@ -151,7 +151,7 @@ class Parameter(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         allow_population_by_field_name = True
         schema_extra = {
             "examples": [

--- a/openapi_schema_pydantic/v3/v3_0_3/path_item.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/path_item.py
@@ -92,7 +92,7 @@ class PathItem(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         allow_population_by_field_name = True
         schema_extra = {
             "examples": [

--- a/openapi_schema_pydantic/v3/v3_0_3/reference.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/reference.py
@@ -16,7 +16,7 @@ class Reference(BaseModel):
     """**REQUIRED**. The reference string."""
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         allow_population_by_field_name = True
         schema_extra = {
             "examples": [{"$ref": "#/components/schemas/Pet"}, {"$ref": "Pet.json"}, {"$ref": "definitions.json#/Pet"}]

--- a/openapi_schema_pydantic/v3/v3_0_3/request_body.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/request_body.py
@@ -31,7 +31,7 @@ class RequestBody(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {

--- a/openapi_schema_pydantic/v3/v3_0_3/response.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/response.py
@@ -44,7 +44,7 @@ class Response(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {

--- a/openapi_schema_pydantic/v3/v3_0_3/schema.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/schema.py
@@ -473,7 +473,7 @@ class Schema(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         allow_population_by_field_name = True
         schema_extra = {
             "examples": [

--- a/openapi_schema_pydantic/v3/v3_0_3/security_scheme.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/security_scheme.py
@@ -66,7 +66,7 @@ class SecurityScheme(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         allow_population_by_field_name = True
         schema_extra = {
             "examples": [

--- a/openapi_schema_pydantic/v3/v3_0_3/server.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/server.py
@@ -31,7 +31,7 @@ class Server(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {"url": "https://development.gigantic-server.com/v1", "description": "Development server"},

--- a/openapi_schema_pydantic/v3/v3_0_3/server_variable.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/server_variable.py
@@ -28,4 +28,4 @@ class ServerVariable(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow

--- a/openapi_schema_pydantic/v3/v3_0_3/tag.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/tag.py
@@ -28,5 +28,5 @@ class Tag(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {"examples": [{"name": "pet", "description": "Pets operations"}]}

--- a/openapi_schema_pydantic/v3/v3_0_3/xml.py
+++ b/openapi_schema_pydantic/v3/v3_0_3/xml.py
@@ -48,7 +48,7 @@ class XML(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {"namespace": "http://example.com/schema/sample", "prefix": "sample"},

--- a/openapi_schema_pydantic/v3/v3_1_0/components.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/components.py
@@ -53,7 +53,7 @@ class Components(BaseModel):
     """An object to hold reusable [Path Item Object](#pathItemObject)."""
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {

--- a/openapi_schema_pydantic/v3/v3_1_0/contact.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/contact.py
@@ -26,7 +26,7 @@ class Contact(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {"name": "API Support", "url": "http://www.example.com/support", "email": "support@example.com"}

--- a/openapi_schema_pydantic/v3/v3_1_0/discriminator.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/discriminator.py
@@ -25,7 +25,7 @@ class Discriminator(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {

--- a/openapi_schema_pydantic/v3/v3_1_0/encoding.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/encoding.py
@@ -71,7 +71,7 @@ class Encoding(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {

--- a/openapi_schema_pydantic/v3/v3_1_0/example.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/example.py
@@ -34,7 +34,7 @@ class Example(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {"summary": "A foo example", "value": {"foo": "bar"}},

--- a/openapi_schema_pydantic/v3/v3_1_0/external_documentation.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/external_documentation.py
@@ -19,5 +19,5 @@ class ExternalDocumentation(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {"examples": [{"description": "Find more info here", "url": "https://example.com"}]}

--- a/openapi_schema_pydantic/v3/v3_1_0/header.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/header.py
@@ -17,7 +17,7 @@ class Header(Parameter):
     param_in = Field(default=ParameterLocation.HEADER, const=True, alias="in")
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         allow_population_by_field_name = True
         schema_extra = {
             "examples": [

--- a/openapi_schema_pydantic/v3/v3_1_0/info.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/info.py
@@ -52,7 +52,7 @@ class Info(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {

--- a/openapi_schema_pydantic/v3/v3_1_0/license.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/license.py
@@ -27,7 +27,7 @@ class License(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {"name": "Apache 2.0", "identifier": "Apache-2.0"},

--- a/openapi_schema_pydantic/v3/v3_1_0/link.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/link.py
@@ -63,7 +63,7 @@ class Link(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {"operationId": "getUserAddressByUUID", "parameters": {"userUuid": "$response.body#/uuid"}},

--- a/openapi_schema_pydantic/v3/v3_1_0/media_type.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/media_type.py
@@ -49,7 +49,7 @@ class MediaType(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         allow_population_by_field_name = True
         schema_extra = {
             "examples": [

--- a/openapi_schema_pydantic/v3/v3_1_0/oauth_flow.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/oauth_flow.py
@@ -39,7 +39,7 @@ class OAuthFlow(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {

--- a/openapi_schema_pydantic/v3/v3_1_0/oauth_flows.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/oauth_flows.py
@@ -35,4 +35,4 @@ class OAuthFlows(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow

--- a/openapi_schema_pydantic/v3/v3_1_0/open_api.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/open_api.py
@@ -87,4 +87,4 @@ class OpenAPI(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow

--- a/openapi_schema_pydantic/v3/v3_1_0/operation.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/operation.py
@@ -107,7 +107,7 @@ class Operation(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {

--- a/openapi_schema_pydantic/v3/v3_1_0/parameter.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/parameter.py
@@ -151,7 +151,7 @@ class Parameter(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         allow_population_by_field_name = True
         schema_extra = {
             "examples": [

--- a/openapi_schema_pydantic/v3/v3_1_0/path_item.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/path_item.py
@@ -93,7 +93,7 @@ class PathItem(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         allow_population_by_field_name = True
         schema_extra = {
             "examples": [

--- a/openapi_schema_pydantic/v3/v3_1_0/reference.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/reference.py
@@ -30,7 +30,7 @@ class Reference(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         allow_population_by_field_name = True
         schema_extra = {
             "examples": [{"$ref": "#/components/schemas/Pet"}, {"$ref": "Pet.json"}, {"$ref": "definitions.json#/Pet"}]

--- a/openapi_schema_pydantic/v3/v3_1_0/request_body.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/request_body.py
@@ -31,7 +31,7 @@ class RequestBody(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {

--- a/openapi_schema_pydantic/v3/v3_1_0/response.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/response.py
@@ -44,7 +44,7 @@ class Response(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {

--- a/openapi_schema_pydantic/v3/v3_1_0/schema.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/schema.py
@@ -832,7 +832,7 @@ class Schema(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         allow_population_by_field_name = True
         schema_extra = {
             "examples": [

--- a/openapi_schema_pydantic/v3/v3_1_0/security_scheme.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/security_scheme.py
@@ -72,7 +72,7 @@ class SecurityScheme(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         allow_population_by_field_name = True
         schema_extra = {
             "examples": [

--- a/openapi_schema_pydantic/v3/v3_1_0/server.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/server.py
@@ -31,7 +31,7 @@ class Server(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {"url": "https://development.gigantic-server.com/v1", "description": "Development server"},

--- a/openapi_schema_pydantic/v3/v3_1_0/server_variable.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/server_variable.py
@@ -28,4 +28,4 @@ class ServerVariable(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow

--- a/openapi_schema_pydantic/v3/v3_1_0/tag.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/tag.py
@@ -28,5 +28,5 @@ class Tag(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {"examples": [{"name": "pet", "description": "Pets operations"}]}

--- a/openapi_schema_pydantic/v3/v3_1_0/xml.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/xml.py
@@ -48,7 +48,7 @@ class XML(BaseModel):
     """
 
     class Config:
-        extra = Extra.ignore
+        extra = Extra.allow
         schema_extra = {
             "examples": [
                 {"name": "animal"},


### PR DESCRIPTION
Change from extra.ignore to extra.allow to allow downstream libraries to make use of extra annotations such as schema extensions.

Initially, no guarantees are provided on support for this feature beyond exposing parsed attributes on a best effort basis, but we'll likely fail on procedures etc and only support basic types.